### PR TITLE
More plumbing for policy

### DIFF
--- a/cmd/rsl.go
+++ b/cmd/rsl.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/adityasaky/gittuf/internal/common"
 	"github.com/adityasaky/gittuf/rsl"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/spf13/cobra"
@@ -32,6 +33,9 @@ func init() {
 }
 
 func runRslInit(cmd *cobra.Command, args []string) error {
+	if err := common.InitializeGittufNamespace("."); err != nil {
+		return err
+	}
 	return rsl.InitializeNamespace()
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/adityasaky/gittuf
 go 1.19
 
 require (
+	github.com/go-git/go-billy/v5 v5.4.1
 	github.com/go-git/go-git/v5 v5.6.1
 	github.com/jonboulle/clockwork v0.3.0
 	github.com/secure-systems-lab/go-securesystemslib v0.5.0
@@ -18,7 +19,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
-	github.com/go-git/go-billy/v5 v5.4.1 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -4,10 +4,44 @@ import (
 	"bytes"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/go-git/go-git/v5"
 )
+
+const GittufNamespace = "refs/gittuf"
+
+// InitializeGittufNamespace creates the refs/gittuf directory if it does not
+// already exist. It does not initialize the refs for policy and RSL namespaces.
+func InitializeGittufNamespace(targetDir string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	if err := os.Chdir(targetDir); err != nil {
+		return err
+	}
+	defer os.Chdir(cwd) //nolint:errcheck
+
+	repoRootDir, err := GetRepositoryRootDirectory()
+	if err != nil {
+		return err
+	}
+
+	refPath := filepath.Join(repoRootDir, GetGitDir(), GittufNamespace)
+	if _, err := os.Stat(refPath); err != nil {
+		if os.IsNotExist(err) {
+			if err := os.Mkdir(refPath, 0755); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	return nil
+}
 
 func GetRepositoryRootDirectory() (string, error) {
 	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
@@ -33,6 +67,16 @@ func CreateTestRepository() (string, error) {
 	if err != nil {
 		return testDir, err
 	}
+
 	cmd := exec.Command("git", "init", testDir)
-	return testDir, cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return testDir, err
+	}
+
+	return testDir, InitializeGittufNamespace(testDir)
+}
+
+func GetGitDir() string {
+	// TODO: handle detached gitdir
+	return ".git"
 }

--- a/internal/gitinterface/blob.go
+++ b/internal/gitinterface/blob.go
@@ -1,0 +1,49 @@
+package gitinterface
+
+import (
+	"errors"
+	"io"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+var ErrWrittenBlobLengthMismatch = errors.New("length of blob written does not match length of contents")
+
+// ReadBlob returns the contents of a the blob referenced by blobID.
+func ReadBlob(repo *git.Repository, blobID plumbing.Hash) ([]byte, error) {
+	blob, err := repo.BlobObject(blobID)
+	if err != nil {
+		return nil, err
+	}
+
+	reader, err := blob.Reader()
+	if err != nil {
+		return nil, err
+	}
+
+	return io.ReadAll(reader)
+}
+
+// WriteBlob creates a blob object with the specified contents and returns the
+// ID of the resultant blob.
+func WriteBlob(repo *git.Repository, contents []byte) (plumbing.Hash, error) {
+	obj := repo.Storer.NewEncodedObject()
+	obj.SetType(plumbing.BlobObject)
+
+	writer, err := obj.Writer()
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	length, err := writer.Write(contents)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	if length != len(contents) {
+		return plumbing.ZeroHash, ErrWrittenBlobLengthMismatch
+	}
+
+	return repo.Storer.SetEncodedObject(obj)
+}

--- a/internal/gitinterface/blob_test.go
+++ b/internal/gitinterface/blob_test.go
@@ -1,0 +1,110 @@
+package gitinterface
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadBlob(t *testing.T) {
+	readContents := []byte("test file read")
+
+	repo, err := git.Init(memory.NewStorage(), memfs.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testObj := repo.Storer.NewEncodedObject()
+	testObj.SetType(plumbing.BlobObject)
+
+	writer, err := testObj.Writer()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	length, err := writer.Write(readContents)
+	if err != nil {
+		t.Fatal(err)
+	} else if length != len(readContents) {
+		t.Fatal(fmt.Errorf("unable to write all of test contents"))
+	}
+
+	writtenHash, err := repo.Storer.SetEncodedObject(testObj)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("test expected file", func(t *testing.T) {
+		expectedHash := "2ecdd330475d93568ed27f717a84a7fe207d1c58"
+
+		contents, err := ReadBlob(repo, plumbing.NewHash(expectedHash))
+		if err != nil {
+			t.Error(err)
+		}
+
+		assert.Equal(t, expectedHash, writtenHash.String())
+		assert.Equal(t, readContents, contents)
+	})
+
+	t.Run("test non existent blob", func(t *testing.T) {
+		_, err := ReadBlob(repo, plumbing.ZeroHash)
+		assert.ErrorIs(t, err, plumbing.ErrObjectNotFound)
+	})
+
+	t.Run("test non blob", func(t *testing.T) {
+		treeHash, err := WriteTree(repo, []object.TreeEntry{
+			{
+				Name: "blob",
+				Mode: filemode.Regular,
+				Hash: writtenHash,
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = ReadBlob(repo, treeHash)
+		assert.ErrorIs(t, err, plumbing.ErrObjectNotFound)
+	})
+}
+
+func TestWriteBlob(t *testing.T) {
+	writeContents := []byte("test file write")
+
+	repo, err := git.Init(memory.NewStorage(), memfs.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blobID, err := WriteBlob(repo, []byte(writeContents))
+	if err != nil {
+		t.Error(err)
+	}
+
+	expectedHash := plumbing.NewHash("999c05e9578e5d244920306842f516789a2498f7")
+	assert.Equal(t, expectedHash, blobID)
+
+	obj, err := repo.BlobObject(blobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := obj.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writtenContents, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, writeContents, writtenContents)
+}

--- a/internal/gitinterface/keys_test.go
+++ b/internal/gitinterface/keys_test.go
@@ -12,10 +12,10 @@ import (
 func TestGetSigningInfo(t *testing.T) {
 	testDir, err := common.CreateTestRepository()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if err := os.Chdir(testDir); err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	repo, err := common.GetRepositoryHandler()

--- a/internal/gitinterface/tree.go
+++ b/internal/gitinterface/tree.go
@@ -1,0 +1,25 @@
+package gitinterface
+
+import (
+	"sort"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// WriteTree creates a Git tree with the specified entries. It sorts the entries
+// prior to creating the tree.
+func WriteTree(repo *git.Repository, entries []object.TreeEntry) (plumbing.Hash, error) {
+	sort.Slice(entries, func(i int, j int) bool {
+		return entries[i].Name < entries[j].Name
+	})
+	obj := repo.Storer.NewEncodedObject()
+	tree := object.Tree{
+		Entries: entries,
+	}
+	if err := tree.Encode(obj); err != nil {
+		return plumbing.ZeroHash, err
+	}
+	return repo.Storer.SetEncodedObject(obj)
+}

--- a/internal/gitinterface/tree_test.go
+++ b/internal/gitinterface/tree_test.go
@@ -1,0 +1,57 @@
+package gitinterface
+
+import (
+	"testing"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriteTree(t *testing.T) {
+	repo, err := git.Init(memory.NewStorage(), memfs.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	readContents := []byte("test file read")
+	readHash, err := WriteBlob(repo, readContents)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writeContents := []byte("test file write")
+	writeHash, err := WriteBlob(repo, writeContents)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entries := []object.TreeEntry{
+		{
+			Name: "test-file-read",
+			Mode: filemode.Regular,
+			Hash: readHash,
+		},
+		{
+			Name: "test-file-write",
+			Mode: filemode.Regular,
+			Hash: writeHash,
+		},
+	}
+
+	treeHash, err := WriteTree(repo, entries)
+	if err != nil {
+		t.Error(err)
+	}
+
+	tree, err := repo.TreeObject(treeHash)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, "e8df153fd5749966e7ddf148fcbee17d747753ae", treeHash.String())
+	assert.Equal(t, entries, tree.Entries)
+}

--- a/internal/gitinterface/utils.go
+++ b/internal/gitinterface/utils.go
@@ -1,0 +1,59 @@
+package gitinterface
+
+import (
+	"fmt"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+// GetTip returns the hash of the tip of the specified ref.
+func GetTip(repo *git.Repository, refName string) (plumbing.Hash, error) {
+	ref, err := repo.Reference(plumbing.ReferenceName(refName), true)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	return ref.Hash(), nil
+}
+
+// ResetCommit sets a Git reference with the name refName to the commit
+// specified by its hash as commitID. Note that the commit must already be in
+// the repository's object store.
+func ResetCommit(repo *git.Repository, refName string, commitID plumbing.Hash) error {
+	currentHEAD, err := repo.Head()
+	if err != nil {
+		return err
+	}
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		return err
+	}
+
+	if err := wt.Checkout(&git.CheckoutOptions{Branch: plumbing.ReferenceName(refName)}); err != nil {
+		return err
+	}
+
+	if err := wt.Reset(&git.ResetOptions{Commit: commitID, Mode: git.MergeReset}); err != nil {
+		return err
+	}
+
+	if currentHEAD.Type() == plumbing.HashReference {
+		return wt.Checkout(&git.CheckoutOptions{Hash: currentHEAD.Hash()})
+	}
+
+	return wt.Checkout(&git.CheckoutOptions{Branch: currentHEAD.Name()})
+}
+
+// ResetDueToError is a helper used to reverse a change applied to a ref due to
+// an error encountered after the change but part of the same operation. This
+// ensures that gittuf operations are atomic. Otherwise, a repository may enter
+// a violation state where a ref is updated without accompanying RSL entries or
+// other metadata changes.
+func ResetDueToError(cause error, repo *git.Repository, refName string, commitID plumbing.Hash) error {
+	if err := ResetCommit(repo, refName, commitID); err != nil {
+		return fmt.Errorf("unable to reset %s to %s, caused by following error: %w", refName, commitID.String(), cause)
+	}
+	return cause
+}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1,0 +1,43 @@
+package policy
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/adityasaky/gittuf/internal/common"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+const (
+	PolicyRef        = "refs/gittuf/policy"
+	PolicyStagingRef = "refs/gittuf/policy-staging"
+)
+
+// InitializeNamespace creates a git ref for the policy. Initially, the entry
+// has a zero hash.
+// Note: policy.InitializeNamespace assumes the gittuf namespace has been
+// created already.
+func InitializeNamespace() error {
+	repoRootDir, err := common.GetRepositoryRootDirectory()
+	if err != nil {
+		return err
+	}
+
+	refPaths := []string{
+		filepath.Join(repoRootDir, common.GetGitDir(), PolicyRef),
+		filepath.Join(repoRootDir, common.GetGitDir(), PolicyStagingRef),
+	}
+	for _, refPath := range refPaths {
+		if _, err := os.Stat(refPath); err != nil {
+			if os.IsNotExist(err) {
+				if err := os.WriteFile(refPath, plumbing.ZeroHash[:], 0644); err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/signerverifier/dsse/dsse_test.go
+++ b/internal/signerverifier/dsse/dsse_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	d "github.com/secure-systems-lab/go-securesystemslib/dsse"
@@ -27,7 +27,7 @@ func TestVerifyEnvelope(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	publicKeyPath := path.Join("test-data", "test-key.pub")
+	publicKeyPath := filepath.Join("test-data", "test-key.pub")
 	publicKeyBytes, err := os.ReadFile(publicKeyPath)
 	if err != nil {
 		t.Fatal(err)
@@ -37,7 +37,7 @@ func TestVerifyEnvelope(t *testing.T) {
 }
 
 func createSignedEnvelope() (*d.Envelope, error) {
-	privateKeyPath := path.Join("test-data", "test-key")
+	privateKeyPath := filepath.Join("test-data", "test-key")
 	privateKeyBytes, err := os.ReadFile(privateKeyPath)
 	if err != nil {
 		return &d.Envelope{}, err

--- a/internal/signerverifier/ed25519/ed25519_test.go
+++ b/internal/signerverifier/ed25519/ed25519_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	e "crypto/ed25519"
@@ -16,7 +16,7 @@ import (
 
 func TestNewSignerVerifierFromSecureSystemsLibFormat(t *testing.T) {
 	t.Run("test private key", func(t *testing.T) {
-		privateKeyPath := path.Join("test-data", "test-key")
+		privateKeyPath := filepath.Join("test-data", "test-key")
 		privateKeyBytes, err := os.ReadFile(privateKeyPath)
 		if err != nil {
 			t.Fatal(err)
@@ -39,7 +39,7 @@ func TestNewSignerVerifierFromSecureSystemsLibFormat(t *testing.T) {
 	})
 
 	t.Run("test public key", func(t *testing.T) {
-		publicKeyPath := path.Join("test-data", "test-key.pub")
+		publicKeyPath := filepath.Join("test-data", "test-key.pub")
 		publicKeyBytes, err := os.ReadFile(publicKeyPath)
 		if err != nil {
 			t.Fatal(err)
@@ -61,7 +61,7 @@ func TestNewSignerVerifierFromSecureSystemsLibFormat(t *testing.T) {
 }
 
 func TestNewSignerVerifierFromTUFKey(t *testing.T) {
-	publicKeyPath := path.Join("test-data", "test-key.pub")
+	publicKeyPath := filepath.Join("test-data", "test-key.pub")
 	publicKeyBytes, err := os.ReadFile(publicKeyPath)
 	if err != nil {
 		t.Fatal(err)
@@ -86,7 +86,7 @@ func TestNewSignerVerifierFromTUFKey(t *testing.T) {
 }
 
 func TestEd25519SignerVeriferSign(t *testing.T) {
-	privateKeyPath := path.Join("test-data", "test-key")
+	privateKeyPath := filepath.Join("test-data", "test-key")
 	privateKeyBytes, err := os.ReadFile(privateKeyPath)
 	if err != nil {
 		t.Fatal(err)
@@ -107,7 +107,7 @@ func TestEd25519SignerVeriferSign(t *testing.T) {
 	expectedSignature := []byte{0x80, 0x72, 0xb4, 0x31, 0xc5, 0xa3, 0x7e, 0xc, 0xf3, 0x91, 0x22, 0x3, 0x60, 0xbf, 0x92, 0xa4, 0x46, 0x31, 0x84, 0x83, 0xf1, 0x31, 0x3, 0xdc, 0xbc, 0x5, 0x6f, 0xab, 0x84, 0xe4, 0xdc, 0xe9, 0xf5, 0x1c, 0xa9, 0xb3, 0x95, 0xa5, 0xa0, 0x16, 0xd3, 0xaa, 0x4d, 0xe7, 0xde, 0xaf, 0xc2, 0x5e, 0x1e, 0x9a, 0x9d, 0xc8, 0xb2, 0x5c, 0x1c, 0x68, 0xf7, 0x28, 0xb4, 0x1, 0x4d, 0x9f, 0xc8, 0x4}
 	assert.Equal(t, expectedSignature, signature)
 
-	publicKeyPath := path.Join("test-data", "test-key.pub")
+	publicKeyPath := filepath.Join("test-data", "test-key.pub")
 	publicKeyBytes, err := os.ReadFile(publicKeyPath)
 	if err != nil {
 		t.Fatal(err)
@@ -123,7 +123,7 @@ func TestEd25519SignerVeriferSign(t *testing.T) {
 }
 
 func TestEd25519SignerVerifierVerify(t *testing.T) {
-	publicKeyPath := path.Join("test-data", "test-key.pub")
+	publicKeyPath := filepath.Join("test-data", "test-key.pub")
 	publicKeyBytes, err := os.ReadFile(publicKeyPath)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/tuf/tuf_test.go
+++ b/internal/tuf/tuf_test.go
@@ -2,14 +2,14 @@ package tuf
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestLoadKeyFromBytes(t *testing.T) {
-	publicKeyPath := path.Join("test-data", "test-key.pub")
+	publicKeyPath := filepath.Join("test-data", "test-key.pub")
 	publicKeyBytes, err := os.ReadFile(publicKeyPath)
 	if err != nil {
 		t.Fatal(err)

--- a/rsl/rsl_test.go
+++ b/rsl/rsl_test.go
@@ -14,10 +14,10 @@ import (
 func TestInitializeNamespace(t *testing.T) {
 	testDir, err := common.CreateTestRepository()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if err := os.Chdir(testDir); err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if err := InitializeNamespace(); err != nil {
@@ -34,10 +34,10 @@ func TestInitializeNamespace(t *testing.T) {
 func TestAddEntry(t *testing.T) {
 	testDir, err := common.CreateTestRepository()
 	if err != nil {
-		t.Error(t)
+		t.Fatal(err)
 	}
 	if err := os.Chdir(testDir); err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if err := InitializeNamespace(); err != nil {
@@ -93,10 +93,10 @@ func TestAddEntry(t *testing.T) {
 func TestGetLatestEntry(t *testing.T) {
 	testDir, err := common.CreateTestRepository()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if err := os.Chdir(testDir); err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if err := InitializeNamespace(); err != nil {


### PR DESCRIPTION
Like #32, this moves some more parts of #27 into a standalone PR.

After this is good to go, we'll be focusing on the pure creation of TUF metadata bits. Side note: I have something based off sigstore/root-signing for generating the root metadata with multiple parties but we should discuss the UX.