### PR TITLE
Add repo handler

### DIFF
--- a/cmd/rsl.go
+++ b/cmd/rsl.go
@@ -61,20 +61,27 @@ func init() {
 }
 
 func runRslInit(cmd *cobra.Command, args []string) error {
-	if err := common.InitializeGittufNamespace("."); err != nil {
+	repo, err := common.GetRepositoryHandler()
+	if err != nil {
 		return err
 	}
-	return rsl.InitializeNamespace()
+
+	return rsl.InitializeNamespace(repo)
 }
 
 func runRslAdd(cmd *cobra.Command, args []string) error {
+	repo, err := common.GetRepositoryHandler()
+	if err != nil {
+		return err
+	}
+
 	if !annotation {
-		return rsl.NewEntry(args[0], plumbing.ZeroHash).Commit(true)
+		return rsl.NewEntry(args[0], plumbing.ZeroHash).Commit(repo, true)
 	}
 
 	entryIDs := []plumbing.Hash{}
 	for _, r := range args {
 		entryIDs = append(entryIDs, plumbing.NewHash(r))
 	}
-	return rsl.NewAnnotation(entryIDs, skip, message).Commit(true)
+	return rsl.NewAnnotation(entryIDs, skip, message).Commit(repo, true)
 }

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -1,65 +1,14 @@
 package common
 
 import (
-	"bytes"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
 
 	"github.com/go-git/go-git/v5"
 )
 
-const GittufNamespace = "refs/gittuf"
-
-// InitializeGittufNamespace creates the refs/gittuf directory if it does not
-// already exist. It does not initialize the refs for policy and RSL namespaces.
-func InitializeGittufNamespace(targetDir string) error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	if err := os.Chdir(targetDir); err != nil {
-		return err
-	}
-	defer os.Chdir(cwd) //nolint:errcheck
-
-	repoRootDir, err := GetRepositoryRootDirectory()
-	if err != nil {
-		return err
-	}
-
-	refPath := filepath.Join(repoRootDir, GetGitDir(), GittufNamespace)
-	if _, err := os.Stat(refPath); err != nil {
-		if os.IsNotExist(err) {
-			if err := os.Mkdir(refPath, 0755); err != nil {
-				return err
-			}
-		} else {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func GetRepositoryRootDirectory() (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
-	var stdout bytes.Buffer
-	cmd.Stdout = &stdout
-	err := cmd.Run()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(stdout.String()), nil
-}
-
 func GetRepositoryHandler() (*git.Repository, error) {
-	repoRoot, err := GetRepositoryRootDirectory()
-	if err != nil {
-		return &git.Repository{}, err
-	}
-	return git.PlainOpen(repoRoot)
+	return git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
 }
 
 func CreateTestRepository() (string, error) {
@@ -69,14 +18,5 @@ func CreateTestRepository() (string, error) {
 	}
 
 	cmd := exec.Command("git", "init", testDir)
-	if err := cmd.Run(); err != nil {
-		return testDir, err
-	}
-
-	return testDir, InitializeGittufNamespace(testDir)
-}
-
-func GetGitDir() string {
-	// TODO: handle detached gitdir
-	return ".git"
+	return testDir, cmd.Run()
 }

--- a/internal/gitinterface/keys_test.go
+++ b/internal/gitinterface/keys_test.go
@@ -20,7 +20,7 @@ func TestGetSigningInfo(t *testing.T) {
 
 	repo, err := common.GetRepositoryHandler()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	tests := map[string]struct {

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1,10 +1,7 @@
 package policy
 
 import (
-	"os"
-	"path/filepath"
-
-	"github.com/adityasaky/gittuf/internal/common"
+	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 )
 
@@ -15,29 +12,10 @@ const (
 
 // InitializeNamespace creates a git ref for the policy. Initially, the entry
 // has a zero hash.
-// Note: policy.InitializeNamespace assumes the gittuf namespace has been
-// created already.
-func InitializeNamespace() error {
-	repoRootDir, err := common.GetRepositoryRootDirectory()
-	if err != nil {
+func InitializeNamespace(repo *git.Repository) error {
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(PolicyRef), plumbing.ZeroHash)); err != nil {
 		return err
 	}
 
-	refPaths := []string{
-		filepath.Join(repoRootDir, common.GetGitDir(), PolicyRef),
-		filepath.Join(repoRootDir, common.GetGitDir(), PolicyStagingRef),
-	}
-	for _, refPath := range refPaths {
-		if _, err := os.Stat(refPath); err != nil {
-			if os.IsNotExist(err) {
-				if err := os.WriteFile(refPath, plumbing.ZeroHash[:], 0644); err != nil {
-					return err
-				}
-			} else {
-				return err
-			}
-		}
-	}
-
-	return nil
+	return repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(PolicyStagingRef), plumbing.ZeroHash))
 }

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -1,0 +1,31 @@
+package repository
+
+import (
+	"github.com/adityasaky/gittuf/internal/common"
+	"github.com/adityasaky/gittuf/internal/policy"
+	"github.com/adityasaky/gittuf/internal/rsl"
+	"github.com/go-git/go-git/v5"
+)
+
+type Repository struct {
+	r *git.Repository
+}
+
+func LoadRepository() (*Repository, error) {
+	repo, err := common.GetRepositoryHandler()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Repository{
+		r: repo,
+	}, nil
+}
+
+func (r *Repository) InitializeNamespaces() error {
+	if err := rsl.InitializeNamespace(r.r); err != nil {
+		return err
+	}
+
+	return policy.InitializeNamespace(r.r)
+}

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -1,0 +1,37 @@
+package repository
+
+import (
+	"os"
+	"testing"
+
+	"github.com/adityasaky/gittuf/internal/common"
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadRepository(t *testing.T) {
+	testDir, err := common.CreateTestRepository()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(testDir); err != nil {
+		t.Fatal(err)
+	}
+
+	repository, err := LoadRepository()
+	assert.Nil(t, err)
+	assert.NotNil(t, repository.r)
+}
+
+func TestInitializeNamespaces(t *testing.T) {
+	repo, err := git.Init(memory.NewStorage(), memfs.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := &Repository{r: repo}
+	err = r.InitializeNamespaces()
+	assert.Nil(t, err)
+}

--- a/internal/rsl/rsl.go
+++ b/internal/rsl/rsl.go
@@ -4,12 +4,10 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/adityasaky/gittuf/internal/common"
 	"github.com/adityasaky/gittuf/internal/gitinterface"
+	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 )
 
@@ -37,30 +35,12 @@ var (
 
 // InitializeNamespace creates a git ref for the reference state log. Initially,
 // the entry has a zero hash.
-// Note: rsl.InitializeNamespace assumes the gittuf namespace has been created
-// already.
-func InitializeNamespace() error {
-	repoRootDir, err := common.GetRepositoryRootDirectory()
-	if err != nil {
-		return err
-	}
-
-	refPath := filepath.Join(repoRootDir, common.GetGitDir(), RSLRef)
-	if _, err := os.Stat(refPath); err != nil {
-		if os.IsNotExist(err) {
-			if err := os.WriteFile(refPath, plumbing.ZeroHash[:], 0644); err != nil {
-				return err
-			}
-		} else {
-			return err
-		}
-	}
-
-	return nil
+func InitializeNamespace(repo *git.Repository) error {
+	return repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(RSLRef), plumbing.ZeroHash))
 }
 
 type EntryType interface {
-	Commit(bool) error
+	Commit(*git.Repository, bool) error
 	createCommitMessage() (string, error)
 }
 
@@ -75,12 +55,7 @@ func NewEntry(refName string, commitID plumbing.Hash) *Entry {
 }
 
 // Commit creates a commit object in the RSL for the Entry.
-func (e Entry) Commit(sign bool) error {
-	repo, err := common.GetRepositoryHandler()
-	if err != nil {
-		return err
-	}
-
+func (e Entry) Commit(repo *git.Repository, sign bool) error {
 	message, _ := e.createCommitMessage() // we have an error return for annotations, always nil here
 
 	return gitinterface.Commit(repo, plumbing.ZeroHash, RSLRef, message, sign)
@@ -109,15 +84,10 @@ func NewAnnotation(rslEntryIDs []plumbing.Hash, skip bool, message string) *Anno
 }
 
 // Commit creates a commit object in the RSL for the Annotation.
-func (a Annotation) Commit(sign bool) error {
-	repo, err := common.GetRepositoryHandler()
-	if err != nil {
-		return err
-	}
-
+func (a Annotation) Commit(repo *git.Repository, sign bool) error {
 	// Check if referred entries exist in the RSL namespace.
 	for _, id := range a.RSLEntryIDs {
-		if _, err := GetEntry(id); err != nil {
+		if _, err := GetEntry(repo, id); err != nil {
 			return err
 		}
 	}
@@ -163,12 +133,7 @@ func (a Annotation) createCommitMessage() (string, error) {
 
 // GetLatestEntry returns the latest entry available locally in the RSL.
 // TODO: There is no information yet about the signature for the entry.
-func GetLatestEntry() (EntryType, error) {
-	repo, err := common.GetRepositoryHandler()
-	if err != nil {
-		return nil, err
-	}
-
+func GetLatestEntry(repo *git.Repository) (EntryType, error) {
 	ref, err := repo.Reference(plumbing.ReferenceName(RSLRef), true)
 	if err != nil {
 		return nil, err
@@ -184,12 +149,7 @@ func GetLatestEntry() (EntryType, error) {
 
 // GetEntry returns the entry corresponding to entryID.
 // TODO: There is no information yet about the signature for the entry.
-func GetEntry(entryID plumbing.Hash) (EntryType, error) {
-	repo, err := common.GetRepositoryHandler()
-	if err != nil {
-		return nil, err
-	}
-
+func GetEntry(repo *git.Repository, entryID plumbing.Hash) (EntryType, error) {
 	ref, err := repo.Reference(plumbing.ReferenceName(RSLRef), true)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The first commit cleans up a lot of the repo handling (and moves several tests to in-memory storage). The second commit adds a lightweight `Repository` handler which (as @wlynch suggested) can provide interfaces that users would use via the CLI.