### PR TITLE
Remove repo parameter when crafting signing command

### DIFF
--- a/internal/gitinterface/commit.go
+++ b/internal/gitinterface/commit.go
@@ -30,7 +30,7 @@ func Commit(repo *git.Repository, treeHash plumbing.Hash, targetRef string, mess
 	commit := createCommitObject(gitConfig, treeHash, curRef.Hash(), message, clockwork.NewRealClock())
 
 	if sign {
-		command, args, err := GetSigningCommand(repo)
+		command, args, err := GetSigningCommand()
 		if err != nil {
 			return err
 		}

--- a/internal/gitinterface/keys.go
+++ b/internal/gitinterface/keys.go
@@ -2,8 +2,6 @@ package gitinterface
 
 import (
 	"errors"
-
-	"github.com/go-git/go-git/v5"
 )
 
 var (
@@ -25,10 +23,10 @@ const (
 	DefaultSigningProgramX509 string = "gpgsm"
 )
 
-func GetSigningCommand(repo *git.Repository) (string, []string, error) {
+func GetSigningCommand() (string, []string, error) {
 	var args []string
 
-	signingMethod, keyInfo, program, err := getSigningInfo(repo)
+	signingMethod, keyInfo, program, err := getSigningInfo()
 	if err != nil {
 		return "", []string{}, err
 	}
@@ -55,7 +53,7 @@ func GetSigningCommand(repo *git.Repository) (string, []string, error) {
 	return program, args, nil
 }
 
-func getSigningInfo(repo *git.Repository) (SigningMethod, string, string, error) {
+func getSigningInfo() (SigningMethod, string, string, error) {
 	gitConfig, err := GetConfig()
 	if err != nil {
 		return -1, "", "", err

--- a/internal/gitinterface/keys_test.go
+++ b/internal/gitinterface/keys_test.go
@@ -114,7 +114,7 @@ func TestGetSigningInfo(t *testing.T) {
 			t.Error(err)
 		}
 
-		signingMethod, keyInfo, program, err := getSigningInfo(repo)
+		signingMethod, keyInfo, program, err := getSigningInfo()
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
I suspect this accidentally stuck around back when I was still trying to use go-git for parsing the config. Alternatively, we can hold off and see if https://github.com/go-git/go-git/pull/760 is approved and we switch over to using go-git.