### PR TITLE
Add RSL functions and interfaces

### DIFF
--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -2,6 +2,7 @@ package root
 
 import (
 	"github.com/adityasaky/gittuf/internal/cmd/policy"
+	"github.com/adityasaky/gittuf/internal/cmd/rsl"
 	"github.com/adityasaky/gittuf/internal/cmd/trust"
 	"github.com/spf13/cobra"
 )
@@ -14,6 +15,7 @@ func New() *cobra.Command {
 
 	cmd.AddCommand(trust.New())
 	cmd.AddCommand(policy.New())
+	cmd.AddCommand(rsl.New())
 
 	return cmd
 }

--- a/internal/cmd/rsl/annotate/annotate.go
+++ b/internal/cmd/rsl/annotate/annotate.go
@@ -1,0 +1,52 @@
+package annotate
+
+import (
+	"github.com/adityasaky/gittuf/internal/repository"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	skip    bool
+	message string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVarP(
+		&o.skip,
+		"skip",
+		"s",
+		false,
+		"mark annotated entries as to be skipped",
+	)
+
+	cmd.Flags().StringVarP(
+		&o.message,
+		"message",
+		"m",
+		"",
+		"annotation message",
+	)
+	cmd.MarkFlagRequired("message") //nolint:errcheck
+}
+
+func (o *options) Run(cmd *cobra.Command, args []string) error {
+	repo, err := repository.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	return repo.RecordRSLAnnotation(args, o.skip, o.message, true)
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:   "annotate",
+		Short: "Annotate prior RSL entries",
+		Args:  cobra.MinimumNArgs(1),
+		RunE:  o.Run,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/cmd/rsl/record/record.go
+++ b/internal/cmd/rsl/record/record.go
@@ -1,0 +1,29 @@
+package record
+
+import (
+	"github.com/adityasaky/gittuf/internal/repository"
+	"github.com/spf13/cobra"
+)
+
+type options struct{}
+
+func (o *options) Run(cmd *cobra.Command, args []string) error {
+	repo, err := repository.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	return repo.RecordRSLEntryForReference(args[0], true)
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:   "record",
+		Short: "Record latest state of a Git reference in the RSL",
+		Args:  cobra.ExactArgs(1),
+		RunE:  o.Run,
+	}
+
+	return cmd
+}

--- a/internal/cmd/rsl/rsl.go
+++ b/internal/cmd/rsl/rsl.go
@@ -1,0 +1,19 @@
+package rsl
+
+import (
+	"github.com/adityasaky/gittuf/internal/cmd/rsl/annotate"
+	"github.com/adityasaky/gittuf/internal/cmd/rsl/record"
+	"github.com/spf13/cobra"
+)
+
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rsl",
+		Short: "Tools to manage the repository's reference state log",
+	}
+
+	cmd.AddCommand(record.New())
+	cmd.AddCommand(annotate.New())
+
+	return cmd
+}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -83,14 +83,9 @@ func TestLoadCurrentState(t *testing.T) {
 func TestLoadStateForEntry(t *testing.T) {
 	repo, state := createTestRepository(t)
 
-	e, err := rsl.GetLatestEntryForRef(repo, PolicyRef)
+	entry, err := rsl.GetLatestEntryForRef(repo, PolicyRef)
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	entry, ok := e.(*rsl.Entry)
-	if !ok {
-		t.Fatal(ErrNotRSLEntry)
 	}
 
 	loadedState, err := LoadStateForEntry(context.Background(), repo, entry)

--- a/internal/repository/rsl.go
+++ b/internal/repository/rsl.go
@@ -1,0 +1,39 @@
+package repository
+
+import (
+	"github.com/adityasaky/gittuf/internal/rsl"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+// RecordRSLEntryForReference is the interface for the user to add an RSL entry
+// for the specified Git reference.
+func (r *Repository) RecordRSLEntryForReference(refName string, signCommit bool) error {
+	absRefName, err := absoluteReference(r.r, refName)
+	if err != nil {
+		return err
+	}
+
+	ref, err := r.r.Reference(plumbing.ReferenceName(absRefName), true)
+	if err != nil {
+		return err
+	}
+
+	// TODO: once policy verification is in place, the signing key used by
+	// signCommit must be verified for the refName in the delegation tree.
+
+	return rsl.NewEntry(absRefName, ref.Hash()).Commit(r.r, signCommit)
+}
+
+// RecordRSLAnnotation is the interface for the user to add an RSL annotation
+// for one or more prior RSL entries.
+func (r *Repository) RecordRSLAnnotation(rslEntryIDs []string, skip bool, message string, signCommit bool) error {
+	rslEntryHashes := []plumbing.Hash{}
+	for _, id := range rslEntryIDs {
+		rslEntryHashes = append(rslEntryHashes, plumbing.NewHash(id))
+	}
+
+	// TODO: once policy verification is in place, the signing key used by
+	// signCommit must be verified for the refNames of the rslEntryIDs.
+
+	return rsl.NewAnnotation(rslEntryHashes, skip, message).Commit(r.r, signCommit)
+}

--- a/internal/repository/rsl_test.go
+++ b/internal/repository/rsl_test.go
@@ -1,0 +1,141 @@
+package repository
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/adityasaky/gittuf/internal/rsl"
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecordRSLEntryForReference(t *testing.T) {
+	r, err := git.Init(memory.NewStorage(), memfs.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := &Repository{r: r}
+
+	if err := rsl.InitializeNamespace(repo.r); err != nil {
+		t.Fatal(err)
+	}
+
+	ref := plumbing.NewHashReference(plumbing.ReferenceName("refs/heads/main"), plumbing.ZeroHash)
+
+	if err := repo.r.Storer.SetReference(ref); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repo.RecordRSLEntryForReference("refs/heads/main", false); err != nil {
+		t.Error(err)
+	}
+
+	rslRef, err := repo.r.Reference(rsl.RSLRef, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entryType, err := rsl.GetEntry(repo.r, rslRef.Hash())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entry, ok := entryType.(*rsl.Entry)
+	if !ok {
+		t.Fatal(fmt.Errorf("invalid entry type"))
+	}
+	assert.Equal(t, "refs/heads/main", entry.RefName)
+	assert.Equal(t, plumbing.ZeroHash, entry.CommitID)
+
+	testHash := plumbing.NewHash("abcdef1234567890")
+
+	ref = plumbing.NewHashReference(plumbing.ReferenceName("refs/heads/main"), testHash)
+	if err := repo.r.Storer.SetReference(ref); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repo.RecordRSLEntryForReference("main", false); err != nil {
+		t.Error(err)
+	}
+
+	rslRef, err = repo.r.Reference(rsl.RSLRef, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entryType, err = rsl.GetEntry(repo.r, rslRef.Hash())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entry, ok = entryType.(*rsl.Entry)
+	if !ok {
+		t.Fatal(fmt.Errorf("invalid entry type"))
+	}
+	assert.Equal(t, "refs/heads/main", entry.RefName)
+	assert.Equal(t, testHash, entry.CommitID)
+}
+
+func TestRecordRSLAnnotation(t *testing.T) {
+	r, err := git.Init(memory.NewStorage(), memfs.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := &Repository{r: r}
+
+	if err := rsl.InitializeNamespace(repo.r); err != nil {
+		t.Fatal(err)
+	}
+
+	ref := plumbing.NewHashReference(plumbing.ReferenceName("refs/heads/main"), plumbing.ZeroHash)
+
+	if err := repo.r.Storer.SetReference(ref); err != nil {
+		t.Fatal(err)
+	}
+
+	err = repo.RecordRSLAnnotation([]string{plumbing.ZeroHash.String()}, false, "test annotation", false)
+	assert.ErrorIs(t, err, rsl.ErrRSLEntryNotFound)
+
+	if err := repo.RecordRSLEntryForReference("refs/heads/main", false); err != nil {
+		t.Fatal(err)
+	}
+
+	latestEntry, err := rsl.GetLatestEntry(repo.r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entryID := latestEntry.GetID()
+
+	err = repo.RecordRSLAnnotation([]string{entryID.String()}, false, "test annotation", false)
+	assert.Nil(t, err)
+
+	latestEntry, err = rsl.GetLatestEntry(repo.r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.IsType(t, &rsl.Annotation{}, latestEntry)
+
+	annotation := latestEntry.(*rsl.Annotation)
+	assert.Equal(t, "test annotation", annotation.Message)
+	assert.Equal(t, []plumbing.Hash{entryID}, annotation.RSLEntryIDs)
+	assert.False(t, annotation.Skip)
+
+	err = repo.RecordRSLAnnotation([]string{entryID.String()}, true, "skip annotation", false)
+	assert.Nil(t, err)
+
+	latestEntry, err = rsl.GetLatestEntry(repo.r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.IsType(t, &rsl.Annotation{}, latestEntry)
+
+	annotation = latestEntry.(*rsl.Annotation)
+	assert.Equal(t, "skip annotation", annotation.Message)
+	assert.Equal(t, []plumbing.Hash{entryID}, annotation.RSLEntryIDs)
+	assert.True(t, annotation.Skip)
+}

--- a/internal/repository/utils.go
+++ b/internal/repository/utils.go
@@ -1,0 +1,39 @@
+package repository
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+var ErrReferenceNotFound = errors.New("reference not found")
+
+func absoluteReference(repo *git.Repository, target string) (string, error) {
+	if strings.HasPrefix(target, "refs/") {
+		return target, nil
+	}
+
+	// Check if branch
+	refName := plumbing.NewBranchReferenceName(target)
+	_, err := repo.Reference(refName, false)
+	if err == nil {
+		return string(refName), nil
+	}
+	if !errors.Is(err, plumbing.ErrReferenceNotFound) {
+		return "", err
+	}
+
+	// Check if tag
+	refName = plumbing.NewTagReferenceName(target)
+	_, err = repo.Reference(refName, false)
+	if err == nil {
+		return string(refName), nil
+	}
+	if !errors.Is(err, plumbing.ErrReferenceNotFound) {
+		return "", err
+	}
+
+	return "", ErrReferenceNotFound
+}


### PR DESCRIPTION
Breaks away the RSL specific changes in #52. In the process, I used some feedback from there to clean up a couple of older APIs given the new ones added here.