### PR TITLE
Use empty tree ID instead of zero for RSL commits

### DIFF
--- a/internal/gitinterface/tree.go
+++ b/internal/gitinterface/tree.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/storage/memory"
 )
 
 // WriteTree creates a Git tree with the specified entries. It sorts the entries
@@ -22,4 +23,15 @@ func WriteTree(repo *git.Repository, entries []object.TreeEntry) (plumbing.Hash,
 		return plumbing.ZeroHash, err
 	}
 	return repo.Storer.SetEncodedObject(obj)
+}
+
+// EmptyTree returns the hash of an empty tree in a Git repository.
+// Note: it is generated on the fly rather than stored as a constant to support
+// SHA-256 repositories in future.
+func EmptyTree() plumbing.Hash {
+	obj := memory.NewStorage().NewEncodedObject()
+	tree := object.Tree{}
+	tree.Encode(obj) //nolint:errcheck
+
+	return obj.Hash()
 }

--- a/internal/gitinterface/tree_test.go
+++ b/internal/gitinterface/tree_test.go
@@ -55,3 +55,11 @@ func TestWriteTree(t *testing.T) {
 	assert.Equal(t, "e8df153fd5749966e7ddf148fcbee17d747753ae", treeHash.String())
 	assert.Equal(t, entries, tree.Entries)
 }
+
+func TestEmptyTree(t *testing.T) {
+	hash := EmptyTree()
+
+	// SHA-1 ID used by Git to denote an empty tree
+	// $ git hash-object -t tree --stdin < /dev/null
+	assert.Equal(t, "4b825dc642cb6eb9a060e54bf8d69288fbee4904", hash.String())
+}

--- a/internal/rsl/rsl.go
+++ b/internal/rsl/rsl.go
@@ -76,7 +76,7 @@ func (e Entry) GetID() plumbing.Hash {
 func (e Entry) Commit(repo *git.Repository, sign bool) error {
 	message, _ := e.createCommitMessage() // we have an error return for annotations, always nil here
 
-	return gitinterface.Commit(repo, plumbing.ZeroHash, RSLRef, message, sign)
+	return gitinterface.Commit(repo, gitinterface.EmptyTree(), RSLRef, message, sign)
 }
 
 func (e Entry) createCommitMessage() (string, error) {
@@ -127,7 +127,7 @@ func (a Annotation) Commit(repo *git.Repository, sign bool) error {
 		return err
 	}
 
-	return gitinterface.Commit(repo, plumbing.ZeroHash, RSLRef, message, sign)
+	return gitinterface.Commit(repo, gitinterface.EmptyTree(), RSLRef, message, sign)
 }
 
 func (a Annotation) createCommitMessage() (string, error) {


### PR DESCRIPTION
Currently, we're using a zero hash for the tree ID for RSL entries. This is flagged as an error by Git, and visible when trying to push to some forges.