### PR TITLE
Support git diff

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -20,6 +20,34 @@ import (
 	"github.com/jonboulle/clockwork"
 )
 
+const (
+	testName  = "Jane Doe"
+	testEmail = "jane.doe@example.com"
+)
+
+var (
+	testGitConfig = &config.Config{
+		Raw: &format.Config{
+			Sections: format.Sections{
+				&format.Section{
+					Name: "user",
+					Options: format.Options{
+						&format.Option{
+							Key:   "name",
+							Value: testName,
+						},
+						&format.Option{
+							Key:   "email",
+							Value: testEmail,
+						},
+					},
+				},
+			},
+		},
+	}
+	testClock = clockwork.NewFakeClockAt(time.Date(1995, time.October, 26, 9, 0, 0, 0, time.UTC))
+)
+
 // CreateTestRSLEntryCommit is a test helper used to create a **signed** RSL
 // entry using the GPG key stored in the repository. It is used to substitute
 // for the default RSL entry creation and signing mechanism which relies on the
@@ -43,17 +71,16 @@ func CreateTestRSLEntryCommit(t *testing.T, repo *git.Repository, entry *rsl.Ent
 		t.Fatal(err)
 	}
 
-	clock := clockwork.NewFakeClockAt(time.Date(1995, time.October, 26, 9, 0, 0, 0, time.UTC))
 	testCommit := &object.Commit{
 		Author: object.Signature{
-			Name:  "Jane Doe",
-			Email: "jane.doe@example.com",
-			When:  clock.Now(),
+			Name:  testName,
+			Email: testEmail,
+			When:  testClock.Now(),
 		},
 		Committer: object.Signature{
-			Name:  "Jane Doe",
-			Email: "jane.doe@example.com",
-			When:  clock.Now(),
+			Name:  testName,
+			Email: testEmail,
+			When:  testClock.Now(),
 		},
 		Message:      commitMessage,
 		TreeHash:     plumbing.ZeroHash,
@@ -147,31 +174,9 @@ func AddNTestCommitsToSpecifiedRef(t *testing.T, repo *git.Repository, refName s
 		t.Fatal(err)
 	}
 
-	gitConfig := &config.Config{
-		Raw: &format.Config{
-			Sections: format.Sections{
-				&format.Section{
-					Name: "user",
-					Options: format.Options{
-						&format.Option{
-							Key:   "name",
-							Value: "Jane Doe",
-						},
-						&format.Option{
-							Key:   "email",
-							Value: "jane.doe@example.com",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	clock := clockwork.NewFakeClockAt(time.Date(1995, time.October, 26, 9, 0, 0, 0, time.UTC))
-
 	commitIDs := []plumbing.Hash{}
 	for i := 0; i < n; i++ {
-		commit := gitinterface.CreateCommitObject(gitConfig, treeHashes[i], ref.Hash(), "Test commit", clock)
+		commit := gitinterface.CreateCommitObject(testGitConfig, treeHashes[i], ref.Hash(), "Test commit", testClock)
 		if err := gitinterface.ApplyCommit(repo, commit, ref); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -13,7 +13,9 @@ import (
 	"github.com/adityasaky/gittuf/internal/gitinterface"
 	"github.com/adityasaky/gittuf/internal/rsl"
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	format "github.com/go-git/go-git/v5/plumbing/format/config"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/jonboulle/clockwork"
 )
@@ -104,4 +106,83 @@ func SignTestCommit(t *testing.T, repo *git.Repository, commit *object.Commit) *
 	commit.PGPSignature = sig.String()
 
 	return commit
+}
+
+// AddNTestCommitsToSpecifiedRef is a test helper that adds test commits to the
+// specified Git ref in the provided repository. Parameter `n` determines how
+// many commits are added. Each commit is associated with a distinct tree. The
+// first commit contains a tree with one object (an empty blob), the second with
+// two objects (both empty blobs), and so on.
+func AddNTestCommitsToSpecifiedRef(t *testing.T, repo *git.Repository, refName string, n int) []plumbing.Hash {
+	t.Helper()
+
+	emptyBlobHash, err := gitinterface.WriteBlob(repo, []byte{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create N trees with 1...N artifacts
+	treeHashes := make([]plumbing.Hash, 0, n)
+	for i := 1; i <= n; i++ {
+		objects := make([]object.TreeEntry, 0, i)
+		for j := 0; j < i; j++ {
+			objects = append(objects, object.TreeEntry{Name: fmt.Sprintf("%d", j+1), Hash: emptyBlobHash})
+		}
+
+		treeHash, err := gitinterface.WriteTree(repo, objects)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		treeHashes = append(treeHashes, treeHash)
+	}
+
+	refNameTyped := plumbing.ReferenceName(refName)
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(refNameTyped, plumbing.ZeroHash)); err != nil {
+		t.Fatal(err)
+	}
+
+	ref, err := repo.Reference(refNameTyped, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gitConfig := &config.Config{
+		Raw: &format.Config{
+			Sections: format.Sections{
+				&format.Section{
+					Name: "user",
+					Options: format.Options{
+						&format.Option{
+							Key:   "name",
+							Value: "Jane Doe",
+						},
+						&format.Option{
+							Key:   "email",
+							Value: "jane.doe@example.com",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	clock := clockwork.NewFakeClockAt(time.Date(1995, time.October, 26, 9, 0, 0, 0, time.UTC))
+
+	commitIDs := []plumbing.Hash{}
+	for i := 0; i < n; i++ {
+		commit := gitinterface.CreateCommitObject(gitConfig, treeHashes[i], ref.Hash(), "Test commit", clock)
+		if err := gitinterface.ApplyCommit(repo, commit, ref); err != nil {
+			t.Fatal(err)
+		}
+
+		ref, err = repo.Reference(refNameTyped, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		commitIDs = append(commitIDs, ref.Hash())
+	}
+
+	return commitIDs
 }

--- a/internal/gitinterface/blob.go
+++ b/internal/gitinterface/blob.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/storage/memory"
 )
 
 var ErrWrittenBlobLengthMismatch = errors.New("length of blob written does not match length of contents")
@@ -46,4 +47,14 @@ func WriteBlob(repo *git.Repository, contents []byte) (plumbing.Hash, error) {
 	}
 
 	return repo.Storer.SetEncodedObject(obj)
+}
+
+// EmptyBlob returns the hash of an empty blob in a Git repository.
+// Note: it is generated on the fly rather than stored as a constant to support
+// SHA-256 repositories in future.
+func EmptyBlob() plumbing.Hash {
+	obj := memory.NewStorage().NewEncodedObject()
+	obj.SetType(plumbing.BlobObject)
+
+	return obj.Hash()
 }

--- a/internal/gitinterface/blob_test.go
+++ b/internal/gitinterface/blob_test.go
@@ -108,3 +108,11 @@ func TestWriteBlob(t *testing.T) {
 	}
 	assert.Equal(t, writeContents, writtenContents)
 }
+
+func TestEmptyBlob(t *testing.T) {
+	hash := EmptyBlob()
+
+	// SHA-1 ID used by Git to denote an empty blob
+	// $ git hash-object -t blob --stdin < /dev/null
+	assert.Equal(t, "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", hash.String())
+}

--- a/internal/gitinterface/changes.go
+++ b/internal/gitinterface/changes.go
@@ -1,0 +1,91 @@
+package gitinterface
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// GetCommitFilePaths returns all the file paths of the provided commit object.
+// This strictly enumerates all the files recursively in the commit object's
+// tree.
+func GetCommitFilePaths(repo *git.Repository, commit *object.Commit) ([]string, error) {
+	filesIter, err := commit.Files()
+	if err != nil {
+		return nil, err
+	}
+
+	paths := []string{}
+	if err := filesIter.ForEach(func(f *object.File) error {
+		paths = append(paths, f.Name)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	sort.Slice(paths, func(i, j int) bool {
+		return paths[i] < paths[j]
+	})
+
+	return paths, nil
+}
+
+// GetDiffFilePaths enumerates all the changed file paths between the two
+// commits. If one of the commits is nil, the other commit's tree is enumerated.
+func GetDiffFilePaths(repo *git.Repository, commitA, commitB *object.Commit) ([]string, error) {
+	if commitA == nil && commitB == nil {
+		return nil, fmt.Errorf("both commits cannot be empty")
+	}
+
+	if commitA == nil {
+		return GetCommitFilePaths(repo, commitB)
+	}
+	if commitB == nil {
+		return GetCommitFilePaths(repo, commitA)
+	}
+
+	treeA, err := commitA.Tree()
+	if err != nil {
+		return nil, err
+	}
+
+	treeB, err := commitB.Tree()
+	if err != nil {
+		return nil, err
+	}
+
+	return diff(treeA, treeB)
+}
+
+// diff is a helper that enumerates and sorts the paths of all files that differ
+// between the two trees. If a file is renamed, both its source name and
+// destination name are recorded.
+func diff(treeA, treeB *object.Tree) ([]string, error) {
+	changesSet := map[string]bool{}
+	changes, err := treeA.Diff(treeB)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, c := range changes {
+		if len(c.From.Name) > 0 {
+			changesSet[c.From.Name] = true
+		}
+		if len(c.To.Name) > 0 {
+			changesSet[c.To.Name] = true
+		}
+	}
+
+	paths := []string{}
+	for p := range changesSet {
+		paths = append(paths, p)
+	}
+
+	sort.Slice(paths, func(i, j int) bool {
+		return paths[i] < paths[j]
+	})
+
+	return paths, nil
+}

--- a/internal/gitinterface/changes_test.go
+++ b/internal/gitinterface/changes_test.go
@@ -1,0 +1,365 @@
+package gitinterface
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	format "github.com/go-git/go-git/v5/plumbing/format/config"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+)
+
+var gitConfig = &config.Config{
+	Raw: &format.Config{
+		Sections: format.Sections{
+			&format.Section{
+				Name: "user",
+				Options: format.Options{
+					&format.Option{
+						Key:   "name",
+						Value: "Jane Doe",
+					},
+					&format.Option{
+						Key:   "email",
+						Value: "jane.doe@example.com",
+					},
+				},
+			},
+		},
+	},
+}
+
+var clock = clockwork.NewFakeClockAt(time.Date(1995, time.October, 26, 9, 0, 0, 0, time.UTC))
+
+func TestGetCommitFilePaths(t *testing.T) {
+	repo, err := git.Init(memory.NewStorage(), memfs.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	emptyBlobHash := EmptyBlob()
+
+	tests := map[string]struct {
+		treeEntries   []object.TreeEntry
+		expectedPaths []string
+	}{
+		"one file": {
+			treeEntries: []object.TreeEntry{
+				{
+					Name: "a",
+					Mode: filemode.Regular,
+					Hash: emptyBlobHash,
+				},
+			},
+			expectedPaths: []string{"a"},
+		},
+		"multiple files": {
+			treeEntries: []object.TreeEntry{
+				{
+					Name: "a",
+					Mode: filemode.Regular,
+					Hash: emptyBlobHash,
+				},
+				{
+					Name: "b",
+					Mode: filemode.Regular,
+					Hash: emptyBlobHash,
+				},
+			},
+			expectedPaths: []string{"a", "b"},
+		},
+		"no files": {
+			treeEntries:   []object.TreeEntry{},
+			expectedPaths: []string{},
+		},
+	}
+
+	for name, test := range tests {
+		WriteBlob(repo, []byte{}) //nolint: errcheck
+		treeHash, err := WriteTree(repo, test.treeEntries)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		c := CreateCommitObject(gitConfig, treeHash, plumbing.ZeroHash, "Test commit", clock)
+		commitID, err := WriteCommit(repo, c)
+		if err != nil {
+			t.Fatal(err)
+		}
+		commit, err := repo.CommitObject(commitID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		paths, err := GetCommitFilePaths(repo, commit)
+		assert.Nil(t, err, fmt.Sprintf("unexpected error in test %s", name))
+		assert.Equal(t, test.expectedPaths, paths, fmt.Sprintf("unexpected list of files received: expected %v, got %v in test %s", test.expectedPaths, paths, name))
+	}
+}
+
+func TestGetDiffFilePaths(t *testing.T) {
+	repo, err := git.Init(memory.NewStorage(), memfs.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blobIDs := []plumbing.Hash{}
+	for i := 0; i < 3; i++ {
+		blobID, err := WriteBlob(repo, []byte(fmt.Sprintf("%d", i)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		blobIDs = append(blobIDs, blobID)
+	}
+
+	t.Run("modify single file", func(t *testing.T) {
+		treeA, err := WriteTree(repo, []object.TreeEntry{{Name: "a", Mode: filemode.Regular, Hash: blobIDs[0]}})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		treeB, err := WriteTree(repo, []object.TreeEntry{{Name: "a", Mode: filemode.Regular, Hash: blobIDs[1]}})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cA := CreateCommitObject(gitConfig, treeA, plumbing.ZeroHash, "Test commit", clock)
+		cAID, err := WriteCommit(repo, cA)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cB := CreateCommitObject(gitConfig, treeB, plumbing.ZeroHash, "Test commit", clock)
+		cBID, err := WriteCommit(repo, cB)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		commitA, err := repo.CommitObject(cAID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		commitB, err := repo.CommitObject(cBID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		diffs, err := GetDiffFilePaths(repo, commitA, commitB)
+		assert.Nil(t, err)
+		assert.Equal(t, []string{"a"}, diffs)
+	})
+
+	t.Run("rename single file", func(t *testing.T) {
+		treeA, err := WriteTree(repo, []object.TreeEntry{{Name: "a", Mode: filemode.Regular, Hash: blobIDs[0]}})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		treeB, err := WriteTree(repo, []object.TreeEntry{{Name: "b", Mode: filemode.Regular, Hash: blobIDs[0]}})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cA := CreateCommitObject(gitConfig, treeA, plumbing.ZeroHash, "Test commit", clock)
+		cAID, err := WriteCommit(repo, cA)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cB := CreateCommitObject(gitConfig, treeB, plumbing.ZeroHash, "Test commit", clock)
+		cBID, err := WriteCommit(repo, cB)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		commitA, err := repo.CommitObject(cAID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		commitB, err := repo.CommitObject(cBID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		diffs, err := GetDiffFilePaths(repo, commitA, commitB)
+		assert.Nil(t, err)
+		assert.Equal(t, []string{"a", "b"}, diffs)
+	})
+
+	t.Run("swap two files around", func(t *testing.T) {
+		treeA, err := WriteTree(repo, []object.TreeEntry{
+			{Name: "a", Mode: filemode.Regular, Hash: blobIDs[0]},
+			{Name: "b", Mode: filemode.Regular, Hash: blobIDs[1]},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		treeB, err := WriteTree(repo, []object.TreeEntry{
+			{Name: "a", Mode: filemode.Regular, Hash: blobIDs[1]},
+			{Name: "b", Mode: filemode.Regular, Hash: blobIDs[0]},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cA := CreateCommitObject(gitConfig, treeA, plumbing.ZeroHash, "Test commit", clock)
+		cAID, err := WriteCommit(repo, cA)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cB := CreateCommitObject(gitConfig, treeB, plumbing.ZeroHash, "Test commit", clock)
+		cBID, err := WriteCommit(repo, cB)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		commitA, err := repo.CommitObject(cAID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		commitB, err := repo.CommitObject(cBID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		diffs, err := GetDiffFilePaths(repo, commitA, commitB)
+		assert.Nil(t, err)
+		assert.Equal(t, []string{"a", "b"}, diffs)
+	})
+
+	t.Run("create new file", func(t *testing.T) {
+		treeA, err := WriteTree(repo, []object.TreeEntry{
+			{Name: "a", Mode: filemode.Regular, Hash: blobIDs[0]},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		treeB, err := WriteTree(repo, []object.TreeEntry{
+			{Name: "a", Mode: filemode.Regular, Hash: blobIDs[0]},
+			{Name: "b", Mode: filemode.Regular, Hash: blobIDs[1]},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cA := CreateCommitObject(gitConfig, treeA, plumbing.ZeroHash, "Test commit", clock)
+		cAID, err := WriteCommit(repo, cA)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cB := CreateCommitObject(gitConfig, treeB, plumbing.ZeroHash, "Test commit", clock)
+		cBID, err := WriteCommit(repo, cB)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		commitA, err := repo.CommitObject(cAID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		commitB, err := repo.CommitObject(cBID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		diffs, err := GetDiffFilePaths(repo, commitA, commitB)
+		assert.Nil(t, err)
+		assert.Equal(t, []string{"b"}, diffs)
+	})
+
+	t.Run("delete file", func(t *testing.T) {
+		treeA, err := WriteTree(repo, []object.TreeEntry{
+			{Name: "a", Mode: filemode.Regular, Hash: blobIDs[0]},
+			{Name: "b", Mode: filemode.Regular, Hash: blobIDs[1]},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		treeB, err := WriteTree(repo, []object.TreeEntry{
+			{Name: "a", Mode: filemode.Regular, Hash: blobIDs[0]},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cA := CreateCommitObject(gitConfig, treeA, plumbing.ZeroHash, "Test commit", clock)
+		cAID, err := WriteCommit(repo, cA)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cB := CreateCommitObject(gitConfig, treeB, plumbing.ZeroHash, "Test commit", clock)
+		cBID, err := WriteCommit(repo, cB)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		commitA, err := repo.CommitObject(cAID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		commitB, err := repo.CommitObject(cBID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		diffs, err := GetDiffFilePaths(repo, commitA, commitB)
+		assert.Nil(t, err)
+		assert.Equal(t, []string{"b"}, diffs)
+	})
+
+	t.Run("modify file and create new file", func(t *testing.T) {
+		treeA, err := WriteTree(repo, []object.TreeEntry{
+			{Name: "a", Mode: filemode.Regular, Hash: blobIDs[0]},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		treeB, err := WriteTree(repo, []object.TreeEntry{
+			{Name: "a", Mode: filemode.Regular, Hash: blobIDs[2]},
+			{Name: "b", Mode: filemode.Regular, Hash: blobIDs[1]},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cA := CreateCommitObject(gitConfig, treeA, plumbing.ZeroHash, "Test commit", clock)
+		cAID, err := WriteCommit(repo, cA)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cB := CreateCommitObject(gitConfig, treeB, plumbing.ZeroHash, "Test commit", clock)
+		cBID, err := WriteCommit(repo, cB)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		commitA, err := repo.CommitObject(cAID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		commitB, err := repo.CommitObject(cBID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		diffs, err := GetDiffFilePaths(repo, commitA, commitB)
+		assert.Nil(t, err)
+		assert.Equal(t, []string{"a", "b"}, diffs)
+	})
+}

--- a/internal/gitinterface/changes_test.go
+++ b/internal/gitinterface/changes_test.go
@@ -3,41 +3,15 @@ package gitinterface
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/filemode"
-	format "github.com/go-git/go-git/v5/plumbing/format/config"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/storage/memory"
-	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 )
-
-var gitConfig = &config.Config{
-	Raw: &format.Config{
-		Sections: format.Sections{
-			&format.Section{
-				Name: "user",
-				Options: format.Options{
-					&format.Option{
-						Key:   "name",
-						Value: "Jane Doe",
-					},
-					&format.Option{
-						Key:   "email",
-						Value: "jane.doe@example.com",
-					},
-				},
-			},
-		},
-	},
-}
-
-var clock = clockwork.NewFakeClockAt(time.Date(1995, time.October, 26, 9, 0, 0, 0, time.UTC))
 
 func TestGetCommitFilePaths(t *testing.T) {
 	repo, err := git.Init(memory.NewStorage(), memfs.New())
@@ -89,7 +63,7 @@ func TestGetCommitFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		c := CreateCommitObject(gitConfig, treeHash, plumbing.ZeroHash, "Test commit", clock)
+		c := CreateCommitObject(testGitConfig, treeHash, plumbing.ZeroHash, "Test commit", testClock)
 		commitID, err := WriteCommit(repo, c)
 		if err != nil {
 			t.Fatal(err)
@@ -131,13 +105,13 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cA := CreateCommitObject(gitConfig, treeA, plumbing.ZeroHash, "Test commit", clock)
+		cA := CreateCommitObject(testGitConfig, treeA, plumbing.ZeroHash, "Test commit", testClock)
 		cAID, err := WriteCommit(repo, cA)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		cB := CreateCommitObject(gitConfig, treeB, plumbing.ZeroHash, "Test commit", clock)
+		cB := CreateCommitObject(testGitConfig, treeB, plumbing.ZeroHash, "Test commit", testClock)
 		cBID, err := WriteCommit(repo, cB)
 		if err != nil {
 			t.Fatal(err)
@@ -168,13 +142,13 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cA := CreateCommitObject(gitConfig, treeA, plumbing.ZeroHash, "Test commit", clock)
+		cA := CreateCommitObject(testGitConfig, treeA, plumbing.ZeroHash, "Test commit", testClock)
 		cAID, err := WriteCommit(repo, cA)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		cB := CreateCommitObject(gitConfig, treeB, plumbing.ZeroHash, "Test commit", clock)
+		cB := CreateCommitObject(testGitConfig, treeB, plumbing.ZeroHash, "Test commit", testClock)
 		cBID, err := WriteCommit(repo, cB)
 		if err != nil {
 			t.Fatal(err)
@@ -211,13 +185,13 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cA := CreateCommitObject(gitConfig, treeA, plumbing.ZeroHash, "Test commit", clock)
+		cA := CreateCommitObject(testGitConfig, treeA, plumbing.ZeroHash, "Test commit", testClock)
 		cAID, err := WriteCommit(repo, cA)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		cB := CreateCommitObject(gitConfig, treeB, plumbing.ZeroHash, "Test commit", clock)
+		cB := CreateCommitObject(testGitConfig, treeB, plumbing.ZeroHash, "Test commit", testClock)
 		cBID, err := WriteCommit(repo, cB)
 		if err != nil {
 			t.Fatal(err)
@@ -253,13 +227,13 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cA := CreateCommitObject(gitConfig, treeA, plumbing.ZeroHash, "Test commit", clock)
+		cA := CreateCommitObject(testGitConfig, treeA, plumbing.ZeroHash, "Test commit", testClock)
 		cAID, err := WriteCommit(repo, cA)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		cB := CreateCommitObject(gitConfig, treeB, plumbing.ZeroHash, "Test commit", clock)
+		cB := CreateCommitObject(testGitConfig, treeB, plumbing.ZeroHash, "Test commit", testClock)
 		cBID, err := WriteCommit(repo, cB)
 		if err != nil {
 			t.Fatal(err)
@@ -295,13 +269,13 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cA := CreateCommitObject(gitConfig, treeA, plumbing.ZeroHash, "Test commit", clock)
+		cA := CreateCommitObject(testGitConfig, treeA, plumbing.ZeroHash, "Test commit", testClock)
 		cAID, err := WriteCommit(repo, cA)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		cB := CreateCommitObject(gitConfig, treeB, plumbing.ZeroHash, "Test commit", clock)
+		cB := CreateCommitObject(testGitConfig, treeB, plumbing.ZeroHash, "Test commit", testClock)
 		cBID, err := WriteCommit(repo, cB)
 		if err != nil {
 			t.Fatal(err)
@@ -337,13 +311,13 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cA := CreateCommitObject(gitConfig, treeA, plumbing.ZeroHash, "Test commit", clock)
+		cA := CreateCommitObject(testGitConfig, treeA, plumbing.ZeroHash, "Test commit", testClock)
 		cAID, err := WriteCommit(repo, cA)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		cB := CreateCommitObject(gitConfig, treeB, plumbing.ZeroHash, "Test commit", clock)
+		cB := CreateCommitObject(testGitConfig, treeB, plumbing.ZeroHash, "Test commit", testClock)
 		cBID, err := WriteCommit(repo, cB)
 		if err != nil {
 			t.Fatal(err)

--- a/internal/gitinterface/commit_test.go
+++ b/internal/gitinterface/commit_test.go
@@ -13,39 +13,15 @@ import (
 	"github.com/adityasaky/gittuf/internal/signerverifier"
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
-	format "github.com/go-git/go-git/v5/plumbing/format/config"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/storage/memory"
-	"github.com/jonboulle/clockwork"
 	sslibsv "github.com/secure-systems-lab/go-securesystemslib/signerverifier"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateCommitObject(t *testing.T) {
-	gitConfig := &config.Config{
-		Raw: &format.Config{
-			Sections: format.Sections{
-				&format.Section{
-					Name: "user",
-					Options: format.Options{
-						&format.Option{
-							Key:   "name",
-							Value: "Jane Doe",
-						},
-						&format.Option{
-							Key:   "email",
-							Value: "jane.doe@example.com",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	clock := clockwork.NewFakeClockAt(time.Date(1995, time.October, 26, 9, 0, 0, 0, time.UTC))
-	commit := CreateCommitObject(gitConfig, plumbing.ZeroHash, plumbing.ZeroHash, "Test commit", clock)
+	commit := CreateCommitObject(testGitConfig, plumbing.ZeroHash, plumbing.ZeroHash, "Test commit", testClock)
 
 	enc := memory.NewStorage().NewEncodedObject()
 	if err := commit.Encode(enc); err != nil {
@@ -153,17 +129,16 @@ func createTestSignedCommit(t *testing.T) *object.Commit {
 		t.Fatal(err)
 	}
 
-	clock := clockwork.NewFakeClockAt(time.Date(1995, time.October, 26, 9, 0, 0, 0, time.UTC))
 	testCommit := &object.Commit{
 		Author: object.Signature{
-			Name:  "Jane Doe",
-			Email: "jane.doe@example.com",
-			When:  clock.Now(),
+			Name:  testName,
+			Email: testEmail,
+			When:  testClock.Now(),
 		},
 		Committer: object.Signature{
-			Name:  "Jane Doe",
-			Email: "jane.doe@example.com",
-			When:  clock.Now(),
+			Name:  testName,
+			Email: testEmail,
+			When:  testClock.Now(),
 		},
 		Message:  "Test commit",
 		TreeHash: plumbing.ZeroHash,

--- a/internal/gitinterface/commit_test.go
+++ b/internal/gitinterface/commit_test.go
@@ -45,7 +45,7 @@ func TestCreateCommitObject(t *testing.T) {
 	}
 
 	clock := clockwork.NewFakeClockAt(time.Date(1995, time.October, 26, 9, 0, 0, 0, time.UTC))
-	commit := createCommitObject(gitConfig, plumbing.ZeroHash, plumbing.ZeroHash, "Test commit", clock)
+	commit := CreateCommitObject(gitConfig, plumbing.ZeroHash, plumbing.ZeroHash, "Test commit", clock)
 
 	enc := memory.NewStorage().NewEncodedObject()
 	if err := commit.Encode(enc); err != nil {

--- a/internal/gitinterface/common_test.go
+++ b/internal/gitinterface/common_test.go
@@ -1,0 +1,37 @@
+package gitinterface
+
+import (
+	"time"
+
+	"github.com/go-git/go-git/v5/config"
+	format "github.com/go-git/go-git/v5/plumbing/format/config"
+	"github.com/jonboulle/clockwork"
+)
+
+const (
+	testName  = "Jane Doe"
+	testEmail = "jane.doe@example.com"
+)
+
+var (
+	testGitConfig = &config.Config{
+		Raw: &format.Config{
+			Sections: format.Sections{
+				&format.Section{
+					Name: "user",
+					Options: format.Options{
+						&format.Option{
+							Key:   "name",
+							Value: testName,
+						},
+						&format.Option{
+							Key:   "email",
+							Value: testEmail,
+						},
+					},
+				},
+			},
+		},
+	}
+	testClock = clockwork.NewFakeClockAt(time.Date(1995, time.October, 26, 9, 0, 0, 0, time.UTC))
+)


### PR DESCRIPTION
This breaks away some changes from #77.

Specifically, the changes here define a mechanism to get the list of changed file paths between two commits and the ability to derive this from an RSL entry for some namespace.

Note: I've included some test clean up as I noticed I was defining the same config, clock etc a bunch of times. I can submit that separately if needed. That's all in the last commit.